### PR TITLE
Replace references to Autopeering simulator

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,6 @@
-# Contribute to the Autopeering Simulator
+# Contribute to the FPC Simulator
 
-This document describes how to contribute to the Autopeering Simulator.
+This document describes how to contribute to the FPC Simulator.
 
 We encourage everyone with knowledge of IOTA technology to contribute.
 
@@ -24,7 +24,7 @@ If you have a general or technical question, you can use one of the following re
 <summary>Ways to contribute :mag:</summary>
 <br>
 
-To contribute to the Autopeering Simulator on GitHub, you can:
+To contribute to the FPC Simulator on GitHub, you can:
 
 - Report a bug
 - Suggest a new feature
@@ -45,13 +45,13 @@ Please check the following list:
 
 - **Do not open a GitHub issue for [security vulnerabilities](.github/SECURITY.MD)**, instead, please contact us at [security@iota.org](mailto:security@iota.org).
 
-- **Ensure the bug was not already reported** by searching on GitHub under [**Issues**](https://github.com/iotaledger/autopeering-sim/issues). If the bug has already been reported **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
+- **Ensure the bug was not already reported** by searching on GitHub under [**Issues**](https://github.com/iotaledger/fpc-sim/issues). If the bug has already been reported **and the issue is still open**, add a comment to the existing issue instead of opening a new one.
 
 **Note:** If you find a **Closed** issue that seems similar to what you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
 ### Submitting A Bug Report
 
-To report a bug, [open a new issue](https://github.com/iotaledger/autopeering-sim/issues/new), and be sure to include as many details as possible, using the template.
+To report a bug, [open a new issue](https://github.com/iotaledger/fpc-sim/issues/new), and be sure to include as many details as possible, using the template.
 
 **Note:** Minor changes such as fixing a typo can but do not need an open issue.
 
@@ -68,7 +68,7 @@ This section guides you through suggesting a new feature. Following these guidel
 
 ### Before suggesting a new feature
 
-**Ensure the feature has not already been suggested** by searching on GitHub under [**Issues**](https://github.com/iotaledger/autopeering-sim/issues).
+**Ensure the feature has not already been suggested** by searching on GitHub under [**Issues**](https://github.com/iotaledger/fpc-sim/issues).
 
 ### Suggesting a new feature
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,5 +1,5 @@
 ---
-name: Report a bug in the Autopeering Simulator
+name: Report a bug in the FPC Simulator
 about: Create a report to help us improve
 title: ""
 labels: bug

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,5 +1,5 @@
 ---
-name: Request a feature for the Autopeering Simulator
+name: Request a feature for the FPC Simulator
 about: Request a feature
 ---
 


### PR DESCRIPTION
# Description of change

Replaced the references to `Autopeering`  with `FPC`.

## Type of change

Choose a type of change, and delete any options that are not relevant.

- Documentation Fix

## How the change has been tested

Describe the tests that you ran to verify your changes.

Make sure to provide instructions for the maintainer as well as any relevant configurations.

## Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] My code follows the contribution guidelines for this project
- [x] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [] I have added tests that prove my fix is effective or that my feature works
- [] New and existing unit tests pass locally with my changes
